### PR TITLE
Update `webpki` from 0.21 to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tokio-openssl = { version = "0.6", optional = true }
 tokio-rustls = { version = "0.24", optional = true }
 hyper-rustls = { version = "0.24", optional = true }
 
-webpki = { version = "0.21", optional = true }
+webpki = { version = "0.22", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 webpki-roots = { version = "0.21.0", optional = true }
 headers = "0.3"


### PR DESCRIPTION
`webpki` depends on `ring v0.16.*` which does not support riscv64, so I update the `webpki` version for support riscv64.